### PR TITLE
Add S3 bucket to hold uploaded images

### DIFF
--- a/lambda/index.py
+++ b/lambda/index.py
@@ -1,5 +1,20 @@
+import json
+import boto3
+import os
+from botocore.exceptions import ClientError
+
 def lambda_handler(event, context):
-    body = '''
+    s3_client = boto3.client('s3')
+    bucket_name: str = os.environ['BUCKET_NAME']
+    object_name: str = 'test.jpg'
+    s3_resource = boto3.resource('s3')
+    bucket = s3_resource.Bucket(bucket_name)
+
+    images = []
+    for obj in bucket.objects.all():
+        images.append(f"https://{bucket_name}.s3.amazonaws.com/{obj.key}")
+
+    body = f'''
     <!DOCTYPE html>
     <html lang="en">
     <head>
@@ -8,7 +23,17 @@ def lambda_handler(event, context):
     </head>
     <body>
         <h1>Pointless Analogies</h1>
-        <p>Initial lambda function</p>
+        <h2>Images in S3 Bucket</h2>
+    '''
+
+    for image in images:
+        print(image)
+
+    for image in images:
+        body += f"<img src='{image}' alt='S3 Image' style='width:300px;height:auto;'/><br>\n"
+
+    body += '''
+    </body>
     </html>
     '''
 

--- a/pointless_analogies/pointless_analogies_stack.py
+++ b/pointless_analogies/pointless_analogies_stack.py
@@ -1,8 +1,11 @@
 from aws_cdk import (
-    # Duration,
     Stack,
     aws_lambda as _lambda,
-    aws_apigateway as apigw
+    aws_apigateway as apigw,
+    RemovalPolicy,
+    Duration,
+    aws_s3 as s3,
+    aws_iam as iam
 )
 from constructs import Construct
 
@@ -11,12 +14,31 @@ class PointlessAnalogiesStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
+        bucket = s3.Bucket(
+            self,
+            "PA_Images",  # Picture bucket name
+            versioned=False,  # Do not allow multiple versions of the same file
+            block_public_access=s3.BlockPublicAccess(
+                block_public_acls=False,
+                block_public_policy=False,
+                ignore_public_acls=False,
+                restrict_public_buckets=False
+            ),
+            public_read_access=True,  # Pictures are publicly accessible
+            removal_policy=RemovalPolicy.DESTROY,  # Delete all pictures when stack is deleted
+            auto_delete_objects=True  # Auto-delete images when stack is deleted
+        )
+
         test_fun = _lambda.Function(
             self,
             "Index",
             runtime=_lambda.Runtime.PYTHON_3_11,
             handler="index.lambda_handler",
-            code=_lambda.Code.from_asset("lambda/")
+            code=_lambda.Code.from_asset("lambda/"),
+            timeout=Duration.seconds(30),
+            environment={
+                "BUCKET_NAME": bucket.bucket_name
+            }
         )
 
         endpoint = apigw.LambdaRestApi(
@@ -26,6 +48,20 @@ class PointlessAnalogiesStack(Stack):
             rest_api_name="IndexApi"
         )
 
+        bucket.grant_read(test_fun)
+
+        list_bucket_policy = iam.PolicyStatement(
+            actions=["s3:ListBucket"],
+            resources=[bucket.bucket_arn]
+        )
+
+        test_fun.role.attach_inline_policy(
+            iam.Policy(
+                self,
+                "ListBucketPolicy",
+                statements=[list_bucket_policy]
+            )
+        )
         # example resource
         # queue = sqs.Queue(
         #     self, "PointlessAnalogiesQueue",


### PR DESCRIPTION
Resolves #8 

Defines a S3 bucket in the stack to hold uploaded images, making them publically accessible to allow for img src links.

Updates the lambda index function to display each image in the bucket. To test, upload an image into the S3 bucket through the console or AWS CLI command.