### PR TITLE
Add web content bucket and names for both buckets

### DIFF
--- a/pointless_analogies/pointless_analogies_stack.py
+++ b/pointless_analogies/pointless_analogies_stack.py
@@ -28,7 +28,25 @@ class PointlessAnalogiesStack(Stack):
             ),
             public_read_access=True,  # Pictures are publicly accessible
             removal_policy=RemovalPolicy.DESTROY,  # Delete all pictures when stack is deleted
-            auto_delete_objects=True  # Auto-delete images when stack is deleted
+            auto_delete_objects=True,  # Auto-delete images when stack is deleted
+            bucket_name="pointless-analogies-images"
+        )
+
+        web_bucket = s3.Bucket(
+            self,
+            "PA_Web_Content",  # Web content bucket ID
+            versioned=False,  # Do not allow multiple versions of the same file
+            #Turn off blocks for public access. May want to change for final implementation
+            block_public_access=s3.BlockPublicAccess(
+                block_public_acls=False,
+                block_public_policy=False,
+                ignore_public_acls=False,
+                restrict_public_buckets=False
+            ),
+            public_read_access=True,  # Web content is publicly accessible
+            removal_policy=RemovalPolicy.DESTROY,  # Delete all web content when stack is deleted
+            auto_delete_objects=True,  # Auto-delete images when stack is destroyed
+            bucket_name="pointless-analogies-web-content"
         )
 
         # Add Lambda function that serves as site index

--- a/pointless_analogies/pointless_analogies_stack.py
+++ b/pointless_analogies/pointless_analogies_stack.py
@@ -15,7 +15,7 @@ class PointlessAnalogiesStack(Stack):
         super().__init__(scope, construct_id, **kwargs)
 
         # Add S3 Bucket to stack
-        bucket = s3.Bucket(
+        image_bucket = s3.Bucket(
             self,
             "PA_Images",  # Picture bucket name
             versioned=False,  # Do not allow multiple versions of the same file
@@ -45,7 +45,7 @@ class PointlessAnalogiesStack(Stack):
             # Add the bucket name to the environment.
             # This is needed as the bucket name that cdk generates is random
             environment={
-                "BUCKET_NAME": bucket.bucket_name 
+                "BUCKET_NAME": image_bucket.bucket_name 
             }
         )
 
@@ -59,13 +59,13 @@ class PointlessAnalogiesStack(Stack):
         )
 
         # Grant read access for the image bucket to the index lambda
-        bucket.grant_read(test_fun)
+        image_bucket.grant_read(test_fun)
 
         # Create a policy that gives the ability to list bucket contents of the
         # image bucket
         list_bucket_policy = iam.PolicyStatement(
             actions=["s3:ListBucket"],  # Allowed actions...
-            resources=[bucket.bucket_arn]  # for this bucket
+            resources=[image_bucket.bucket_arn]  # for this bucket
         )
 
         # Add the defined policy to the lambda function


### PR DESCRIPTION
Adds a bucket designated to hold web content, and gives both the web content bucket and image bucket a specified name to stop CDK from creating a random name each time.

Helps to resolve #3, by allowing the script to an already determined name instead of trying to get the randomly generated one from the template.

Also resolves #9 