### PR TITLE
Add S3 notification that renames uploaded files to unique name

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import aws_cdk as cdk
 from pointless_analogies.pointless_analogies_stack import PointlessAnalogiesStack
 
 
+
 app = cdk.App()
 PointlessAnalogiesStack(app, "PointlessAnalogiesStack",
     # If you don't specify 'env', this stack will be environment-agnostic.
@@ -15,7 +16,7 @@ PointlessAnalogiesStack(app, "PointlessAnalogiesStack",
     # Uncomment the next line to specialize this stack for the AWS Account
     # and Region that are implied by the current CLI configuration.
 
-    #env=cdk.Environment(account=os.getenv('CDK_DEFAULT_ACCOUNT'), region=os.getenv('CDK_DEFAULT_REGION')),
+    env=cdk.Environment(account=os.getenv('CDK_DEFAULT_ACCOUNT'), region=os.getenv('CDK_DEFAULT_REGION')),
 
     # Uncomment the next line if you know exactly what Account and Region you
     # want to deploy the stack to. */

--- a/lambda/image_handler.py
+++ b/lambda/image_handler.py
@@ -1,0 +1,14 @@
+import boto3
+import uuid
+
+s3 = boto3.client('s3')
+
+def lambda_handler(event, context):
+    for record in event['Records']:
+        bucket = record['s3']['bucket']['name']
+        key = record['s3']['object']['key']
+        new_key = f"uniq-{uuid.uuid4()}"
+        s3.copy_object(Bucket=bucket, Key=new_key, CopySource=f"{bucket}/{key}")
+        s3.delete_object(Bucket=bucket, Key=key)
+    
+    return "Image successfully renamed"


### PR DESCRIPTION
Resolves #21 by creating an S3 notification that renames uploaded files to the S3 bucket a unique ID.

Lambda function that serves as the S3 notification should be given permission to write to the DynamoDB database, and functionality should be added to add the name to the DB, getting two random categories, and setting the initial vote for both to zero.