### PR TITLE
Fix bug where image renaming re-trigger image handler lambda

### DIFF
--- a/lambda/categories.py
+++ b/lambda/categories.py
@@ -14,6 +14,8 @@ def lambda_handler(event, context):
     while sec_result == result:
         sec_result = random.choice(categories)
 
+    print(f"Got two categories: {result} and {sec_result}")
+
     return {
         'statusCode': 200,
         'body': f"{result}-{sec_result}"

--- a/lambda/image_handler.py
+++ b/lambda/image_handler.py
@@ -13,8 +13,17 @@ def lambda_handler(event, context):
 
     for record in event['Records']:
         bucket = record['s3']['bucket']['name']
-        key = record['s3']['object']['key']
+        key: str = record['s3']['object']['key']
+
+        # Quick fix to prevent the lambda from trying to rename an already
+        # renamed file
+        if key.startswith("uniq-"):
+            print("Duplicate found. Continuing")
+            continue
+
         new_key = f"uniq-{uuid.uuid4()}"
+
+        print(f"Created image hash {new_key} to replace {key}")
 
         response = client.invoke(
             FunctionName='get-categories',
@@ -28,6 +37,8 @@ def lambda_handler(event, context):
 
         category1 = split_categories[0]
         category2 = split_categories[1]
+
+        print(f"Got the two categories {category1} and {category2}")
 
         table_response = table.put_item(
             Item = {

--- a/pointless_analogies/pointless_analogies_stack.py
+++ b/pointless_analogies/pointless_analogies_stack.py
@@ -192,7 +192,10 @@ class PointlessAnalogiesStack(Stack):
         image_bucket.grant_read_write(uploaded_images)
 
         image_bucket_notif = s3n.LambdaDestination(uploaded_images)
-        image_bucket.add_event_notification(s3.EventType.OBJECT_CREATED, image_bucket_notif)
+        image_bucket.add_event_notification(
+            s3.EventType.OBJECT_CREATED,
+            image_bucket_notif
+        )
 
         # Create a policy that gives the ability to list bucket contents of the
         # image bucket


### PR DESCRIPTION
Fixes a bug where the renaming of the image would cause the lambda to re-trigger, leading to multiple bad keys to be stored in the dynamodb