### PR TITLE
Fix issue where page content is cut off and give image_handler CloudWatch permissions

### DIFF
--- a/html_templates/image_snippet.html
+++ b/html_templates/image_snippet.html
@@ -1,7 +1,7 @@
 <div class="vote-div">
 <img src='{image}' alt='S3 Image' style='width:300px;height:auto;'/><br>
 <a href = "{apiEndpoint}?ImageHash={imageHash}" target=""_self">
-    <button type=""button">Vote on this image</button>
+    <button type="button">Vote on this image</button>
 </a>
 </div>
 {imagesBegin}

--- a/html_templates/main_page.html
+++ b/html_templates/main_page.html
@@ -8,13 +8,16 @@
         html, body {
             height: 100%;
             margin: 0;
-            display: flex;
+            display: block;
             justify-content: center;
             align-items: center;
+            overflow-x: hidden;
+            overflow-y: auto;
         }
         
         #content {
             text-align: center;
+            min-height: 100vh;
         }
         
         h1 {
@@ -27,8 +30,11 @@
         }
 
         .vote-div {
-            margin-top: 20px;
-            margin-bottom: 20px;
+            width: 300px;
+            margin: 10px auto;
+            padding: 10px;
+            box-sizing: border-box;
+            text-align: center;
         }
     </style>
 </head>

--- a/pointless_analogies/pointless_analogies_stack.py
+++ b/pointless_analogies/pointless_analogies_stack.py
@@ -226,8 +226,9 @@ class PointlessAnalogiesStack(Stack):
             "CategoryInvokePolicy",
             statements=[
                 iam.PolicyStatement(
-                    actions=["lambda:InvokeFunction"],
-                    resources=[f"arn:aws:lambda:{self.region}:{self.account}:function:get-categories"]
+                    actions=["lambda:InvokeFunction", "logs:CreateLogGroup", "logs:createLogStream", "logs:PutLogEvents"],
+                    resources=[f"arn:aws:lambda:{self.region}:{self.account}:function:get-categories",
+                               f"arn:aws:logs:{self.region}:{self.account}:log-group:/aws/lambda/*"]
                 )
             ]
         )


### PR DESCRIPTION
Fixes CSS styling code which caused webpage content to be cut off when several images were being displayed.

Explicitly gives image_handler permissions to create logs in CloudWatch to help track when the lambda is being invoked.