### PR TITLE
Use better fix for image_handler recursion issue

### DIFF
--- a/pointless_analogies/pointless_analogies_stack.py
+++ b/pointless_analogies/pointless_analogies_stack.py
@@ -248,7 +248,7 @@ class PointlessAnalogiesStack(Stack):
         table.grant_read_write_data(uploaded_images)
         image_bucket_notif = s3n.LambdaDestination(uploaded_images)
         image_bucket.add_event_notification(
-            s3.EventType.OBJECT_CREATED,
+            s3.EventType.OBJECT_CREATED_PUT,
             image_bucket_notif
         )
 


### PR DESCRIPTION
Does a better fix for the issue where the image_handler would end up recursively calling itself by only calling the function for puts/uploads, not copies.