### PR TITLE
Fixed issue of images with spaces in their names not being added to the table correctly

### DIFF
--- a/lambda/vote_page_functions.py
+++ b/lambda/vote_page_functions.py
@@ -8,9 +8,9 @@ def vote_page_handler_function(event, context):
     http_method = event['requestContext']['http']['method']
     print(f"HTTP Method: {http_method}")
 
-    if (http_method == "GET"):
+    if http_method == "GET":
         return vote_page_initial_function(event, context)
-    elif (http_method == "POST"):
+    elif http_method == "POST":
         return vote_page_button_function(event, context)
     else:
         return {

--- a/pointless_analogies/pointless_analogies_stack.py
+++ b/pointless_analogies/pointless_analogies_stack.py
@@ -258,8 +258,8 @@ class PointlessAnalogiesStack(Stack):
         table.grant_read_write_data(uploaded_images)
         image_bucket_notif = s3n.LambdaDestination(uploaded_images)
         image_bucket.add_event_notification(
-            s3.EventType.OBJECT_CREATED_PUT,
-            image_bucket_notif
+            event = s3.EventType.OBJECT_CREATED_PUT,
+            dest = image_bucket_notif
         )
 
         # function to return presigned URL for S3


### PR DESCRIPTION
I added a series of try-except statements﻿ to image_handler to ensure that images uploaded with file names containing characters that cannot be included in a url do not break the table. The 
function now goes through a couple rounds of replacing url characters with possible original characters through `urllib.parse.unquote` and `urllib.parse.unquote_plus` to try and get the original 
file name back.
